### PR TITLE
feat: cookie+redis를 활용한 jwt 관리

### DIFF
--- a/backend/.idea/.gitignore
+++ b/backend/.idea/.gitignore
@@ -6,3 +6,5 @@
 # Datasource local storage ignored files
 /dataSources/
 /dataSources.local.xml
+# GitHub Copilot persisted chat sessions
+/copilot/chatSessions

--- a/backend/auth-service/src/main/java/io/ssafy/authservice/auth/controller/AuthController.java
+++ b/backend/auth-service/src/main/java/io/ssafy/authservice/auth/controller/AuthController.java
@@ -13,6 +13,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -58,9 +59,9 @@ public class AuthController {
             @ApiResponse(responseCode = "404", description = "존재하지 않는 회원입니다.")
     })
     @PostMapping("/login")
-    public Response<?> loginMember (@RequestBody MemberLoginReqDto memberLoginReqDto) {
+    public Response<?> loginMember (@RequestBody MemberLoginReqDto memberLoginReqDto, HttpServletResponse response) {
         log.debug("## 로그인을 시도합니다! : {}", memberLoginReqDto);
-        return memberService.loginMember(memberLoginReqDto);
+        return memberService.loginMember(memberLoginReqDto, response);
     }
 
 
@@ -103,6 +104,12 @@ public class AuthController {
     public Response<?> validateEmail (@PathVariable String email) {
         log.debug("## 이메일 중복 검사 : {}", email);
         return memberService.validateEmail(email);
+    }
+
+    @GetMapping("/test")
+    public Response<?> testForToken(@AuthenticationPrincipal User user) {
+        log.debug("## 토큰 테스트 : {}", user);
+        return OK(null);
     }
 
 }

--- a/backend/auth-service/src/main/java/io/ssafy/authservice/global/config/RedisRepositoryConfig.java
+++ b/backend/auth-service/src/main/java/io/ssafy/authservice/global/config/RedisRepositoryConfig.java
@@ -1,5 +1,6 @@
 package io.ssafy.authservice.global.config;
 
+import io.ssafy.authservice.member.entity.TokenRedis;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
@@ -7,11 +8,13 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisKeyValueAdapter;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
 
-@RequiredArgsConstructor
 @Configuration
-
+@EnableRedisRepositories(enableKeyspaceEvents = RedisKeyValueAdapter.EnableKeyspaceEvents.ON_STARTUP)
 public class RedisRepositoryConfig {
 
     @Value("${spring.data.redis.host}")
@@ -34,11 +37,12 @@ public class RedisRepositoryConfig {
     }
 
     @Bean
-    public RedisTemplate<String, Object> redisTemplate() {
-        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+    public RedisTemplate<String, TokenRedis> redisTemplate() {
+        RedisTemplate<String, TokenRedis> redisTemplate = new RedisTemplate<>();
         redisTemplate.setConnectionFactory(redisConnectionFactory());
-        redisTemplate.setDefaultSerializer(redisTemplate.getStringSerializer());
+        redisTemplate.setDefaultSerializer(new GenericJackson2JsonRedisSerializer());
         return redisTemplate;
     }
+
 
 }

--- a/backend/auth-service/src/main/java/io/ssafy/authservice/global/exception/JwtTokenException.java
+++ b/backend/auth-service/src/main/java/io/ssafy/authservice/global/exception/JwtTokenException.java
@@ -1,7 +1,0 @@
-package io.ssafy.authservice.global.exception;
-
-public class JwtTokenException extends RuntimeException{
-    public JwtTokenException(String message){
-        super(message);
-    }
-}

--- a/backend/auth-service/src/main/java/io/ssafy/authservice/global/exception/RefreshTokenExpiredException.java
+++ b/backend/auth-service/src/main/java/io/ssafy/authservice/global/exception/RefreshTokenExpiredException.java
@@ -1,0 +1,10 @@
+package io.ssafy.authservice.global.exception;
+
+import io.jsonwebtoken.ExpiredJwtException;
+
+public class RefreshTokenExpiredException extends RuntimeException {
+
+    public RefreshTokenExpiredException(String message) {
+        super(message);
+    }
+}

--- a/backend/auth-service/src/main/java/io/ssafy/authservice/global/exception/TokenNotFoundException.java
+++ b/backend/auth-service/src/main/java/io/ssafy/authservice/global/exception/TokenNotFoundException.java
@@ -1,0 +1,7 @@
+package io.ssafy.authservice.global.exception;
+
+public class TokenNotFoundException extends RuntimeException{
+    public TokenNotFoundException(String message){
+        super(message);
+    }
+}

--- a/backend/auth-service/src/main/java/io/ssafy/authservice/member/entity/TokenRedis.java
+++ b/backend/auth-service/src/main/java/io/ssafy/authservice/member/entity/TokenRedis.java
@@ -1,0 +1,26 @@
+package io.ssafy.authservice.member.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+import org.springframework.data.redis.core.index.Indexed;
+
+@Getter
+@AllArgsConstructor
+@RedisHash(value = "token", timeToLive = 60 * 60 * 24 * 7) // 7 일
+public class TokenRedis {
+
+    @Id
+    private String id;
+
+    @Indexed
+    private String accessToken;
+
+    private String refreshToken;
+
+    public void updateAccessToken(String accessToken) {
+        this.accessToken = accessToken;
+    }
+
+}

--- a/backend/auth-service/src/main/java/io/ssafy/authservice/member/respository/TokenRedisRepository.java
+++ b/backend/auth-service/src/main/java/io/ssafy/authservice/member/respository/TokenRedisRepository.java
@@ -1,0 +1,12 @@
+package io.ssafy.authservice.member.respository;
+
+import io.ssafy.authservice.member.entity.TokenRedis;
+import org.springframework.data.repository.CrudRepository;
+
+import java.util.Optional;
+
+public interface TokenRedisRepository extends CrudRepository<TokenRedis, String> {
+
+    Optional<TokenRedis> findByAccessToken(String accessToken);
+    boolean existsByAccessToken(String accessToken);
+}

--- a/backend/auth-service/src/main/java/io/ssafy/authservice/member/service/MemberService.java
+++ b/backend/auth-service/src/main/java/io/ssafy/authservice/member/service/MemberService.java
@@ -4,11 +4,12 @@ package io.ssafy.authservice.member.service;
 import io.ssafy.authservice.auth.dto.request.MemberJoinReqDto;
 import io.ssafy.authservice.auth.dto.request.MemberLoginReqDto;
 import io.ssafy.authservice.global.response.Response;
+import jakarta.servlet.http.HttpServletResponse;
 
 public interface MemberService {
 
     Response<?> joinMember (MemberJoinReqDto memberJoinReqDto);
-    Response<?> loginMember (MemberLoginReqDto memberLoginReqDto);
+    Response<?> loginMember (MemberLoginReqDto memberLoginReqDto, HttpServletResponse response);
 
     Response<?> validateNickname (String nickname);
     Response<?> validateEmail (String email);

--- a/backend/auth-service/src/main/java/io/ssafy/authservice/oauth2/cookie/CookieAuthorizationRequestRepository.java
+++ b/backend/auth-service/src/main/java/io/ssafy/authservice/oauth2/cookie/CookieAuthorizationRequestRepository.java
@@ -33,9 +33,6 @@ public class CookieAuthorizationRequestRepository implements AuthorizationReques
 
         CookieUtils.addCookie(response, OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME, CookieUtils.serialize(authorizationRequest), COOKIE_EXPIRE_SECONDS);
         String redirectUriAfterLogin = request.getParameter(REDIRECT_URI_PARAM_COOKIE_NAME);
-//        String redirectUriAfterLogin = redirectURI;
-        log.warn("리다이렉트 주소 : {}", redirectUriAfterLogin);
-
 
         if (StringUtils.isNotBlank(redirectUriAfterLogin)) {
             CookieUtils.addCookie(response, REDIRECT_URI_PARAM_COOKIE_NAME, redirectUriAfterLogin, COOKIE_EXPIRE_SECONDS);

--- a/backend/auth-service/src/main/java/io/ssafy/authservice/oauth2/cookie/CookieUtils.java
+++ b/backend/auth-service/src/main/java/io/ssafy/authservice/oauth2/cookie/CookieUtils.java
@@ -3,6 +3,9 @@ package io.ssafy.authservice.oauth2.cookie;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.stereotype.Component;
 import org.springframework.util.SerializationUtils;
 
 import java.util.Arrays;
@@ -10,6 +13,14 @@ import java.util.Base64;
 import java.util.Optional;
 
 public class CookieUtils {
+
+
+    @Value("${cookie.domain}")
+    private static String cookieResponseDomain;
+
+    @Value("${cookie.max-age}")
+    private static int cookieMaxAge;
+
 
     public static Optional<Cookie> getCookie(HttpServletRequest request, String name) {
         Cookie[] cookies = request.getCookies();
@@ -36,6 +47,16 @@ public class CookieUtils {
         cookie.setHttpOnly(true);
         cookie.setMaxAge(maxAge);
         response.addCookie(cookie);
+    }
+
+    public static Cookie setAccessTokenCookie(String accessToken) {
+        Cookie cookie = new Cookie("accessToken", accessToken);
+        cookie.setPath("/");
+        cookie.setDomain(cookieResponseDomain); // 특정 도메인에서 사용하도록
+        cookie.setHttpOnly(true);
+        cookie.setMaxAge(cookieMaxAge);
+
+        return cookie;
     }
 
     public static void deleteCookie(HttpServletRequest request, HttpServletResponse response, String name) {

--- a/backend/auth-service/src/main/java/io/ssafy/authservice/oauth2/jwt/JwtTokenProvider.java
+++ b/backend/auth-service/src/main/java/io/ssafy/authservice/oauth2/jwt/JwtTokenProvider.java
@@ -3,15 +3,26 @@ package io.ssafy.authservice.oauth2.jwt;
 import io.jsonwebtoken.*;
 import io.jsonwebtoken.io.Decoders;
 import io.jsonwebtoken.security.Keys;
+import io.lettuce.core.RedisException;
 import io.ssafy.authservice.global.config.security.ExpireTime;
-import io.ssafy.authservice.global.exception.JwtTokenException;
+import io.ssafy.authservice.global.exception.TokenNotFoundException;
+import io.ssafy.authservice.member.entity.TokenRedis;
 import io.ssafy.authservice.member.respository.MemberRepository;
+import io.ssafy.authservice.member.respository.TokenRedisRepository;
+import io.ssafy.authservice.oauth2.cookie.CookieUtils;
 import io.ssafy.authservice.oauth2.dto.UserResponseDto;
+import io.ssafy.authservice.oauth2.service.CustomUserDetailsService;
+import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.antlr.v4.runtime.Token;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
@@ -20,6 +31,7 @@ import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 
+import java.io.IOException;
 import java.security.Key;
 import java.util.Arrays;
 import java.util.Collection;
@@ -34,26 +46,32 @@ public class JwtTokenProvider {
     private static final String AUTHORITIES_KEY = "auth";
     private static final String BEARER_TYPE = "Bearer";
     private static final String TYPE_ACCESS = "access";
+    private static final String TYPE_REFRESH = "refresh";
+    @Value("${cookie.domain}")
+    private static String cookieResponseDomain;
+
+    private final RedisTemplate<String, TokenRedis> redisTemplate;
+    
+    @Value("${cookie.max-age}")
+    private int cookieMaxAge;
+
+    private final TokenRedisRepository tokenRedisRepository;
+    private final CustomUserDetailsService customUserDetailsService;
 
     private final Key key;
 
-    // The specified key byte array is 248 bits which is not secure enough for any
-    // JWT HMAC-SHA algorithm.
-    // The JWT JWA Specification (RFC 7518, Section 3.2) states that keys used with
-    // HMAC-SHA algorithms MUST have a size >= 256 bits (the key size must be
-    // greater than or equal to the hash output size).
-    // Consider using the
-    // io.jsonwebtoken.security.Keys#secretKeyFor(SignatureAlgorithm) method to
-    // create a key guaranteed to be secure enough for your preferred HMAC-SHA
-    // algorithm.
-    public JwtTokenProvider(@Value("${token.secret}") String secretKey) {
+
+    public JwtTokenProvider(@Value("${token.secret}") String secretKey, RedisTemplate<String, TokenRedis> redisTemplate, TokenRedisRepository tokenRedisRepository, CustomUserDetailsService customUserDetailsService) {
+        this.redisTemplate = redisTemplate;
+        this.tokenRedisRepository = tokenRedisRepository;
+        this.customUserDetailsService = customUserDetailsService;
         byte[] keyBytes = Decoders.BASE64.decode(secretKey);
         this.key = Keys.hmacShaKeyFor(keyBytes);
     }
 
     // Authentication 을 가지고 AccessToken, RefreshToken 을 생성하는 메서드
     public UserResponseDto.TokenInfo generateToken(Authentication authentication) {
-        log.info("유저 이름 : {}", authentication.getName());
+        log.debug("유저 이름 : {}", authentication.getName());
 
         return generateToken(authentication.getName(), authentication.getAuthorities());
 
@@ -62,25 +80,23 @@ public class JwtTokenProvider {
     // name, authorities 를 가지고 AccessToken, RefreshToken 을 생성하는 메서드
     public UserResponseDto.TokenInfo generateToken(String name,
             Collection<? extends GrantedAuthority> inputAuthorities) {
-        log.info("## 토큰 생성 2 !! : {}", inputAuthorities.stream().toString());
-        log.info(name);
-        // 권한 가져오기
+
+        // 권한 추출
         String authorities = inputAuthorities.stream()
                 .map(GrantedAuthority::getAuthority)
                 .collect(Collectors.joining(","));
 
-        log.debug("{}", inputAuthorities.stream().toString());
         Date now = new Date();
-        log.info("권한: {}", authorities);
-        log.info("권한: {}", authorities);
 
-        // Generate AccessToken
-        String accessToken = Jwts.builder()
-                .setSubject(name)
+        // AccessToken 생성
+        String accessToken = generateAccessToken(name, inputAuthorities);
+
+        // RefreshToken 생성
+        String refreshToken = Jwts.builder()
                 .claim(AUTHORITIES_KEY, authorities)
-                .claim("type", TYPE_ACCESS)
+                .claim("type", TYPE_REFRESH)
                 .setIssuedAt(now) // 토큰 발행 시간 정보
-                .setExpiration(new Date(now.getTime() + ExpireTime.ACCESS_TOKEN_EXPIRE_TIME)) // 토큰 만료 시간 설정
+                .setExpiration(new Date(now.getTime() + ExpireTime.REFRESH_TOKEN__EXPIRE_TIME)) // 토큰 만료 시간 설정
                 .signWith(key, SignatureAlgorithm.HS256)
                 .compact();
 
@@ -88,16 +104,30 @@ public class JwtTokenProvider {
                 .grantType(BEARER_TYPE)
                 .accessToken(accessToken)
                 .accessTokenExpirationTime(ExpireTime.ACCESS_TOKEN_EXPIRE_TIME)
+                .refreshToken(refreshToken)
+                .refreshTokenExpirationTime(ExpireTime.REFRESH_TOKEN__EXPIRE_TIME)
                 .build();
     }
 
-    // JWT 토큰을 복호화하여 토큰에 들어있는 정보를 꺼내는 메서드
-    public Authentication getAuthentication(String accessToken) {
+    /**
+     * 토큰을 이용하여 Authentication 객체를 생성하는 메서드
+     * @param token 토큰
+     * @param memberId 회원 식별자
+     * @return UsernamePasswordAuthenticationToken
+     */
+    public Authentication getAuthentication(String token, String memberId) throws TokenNotFoundException{
         // 토큰 복호화
-        Claims claims = parseClaims(accessToken);
+        Claims claims = Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token).getBody();
+
+        String subject;
+
+        if (claims.get("type").equals("refresh")) {
+            subject = memberId;
+        } else {
+            subject = claims.getSubject();
+        }
 
         if (claims.get(AUTHORITIES_KEY) == null) {
-            // TODO:: Change Custom Exception
             throw new RuntimeException("권한 정보가 없는 토큰입니다.");
         }
 
@@ -107,39 +137,34 @@ public class JwtTokenProvider {
                 .map(SimpleGrantedAuthority::new)
                 .collect(Collectors.toList());
 
-        // UserDetails 객체를 만들어서 Authentication 리턴
-        log.debug("클레임 : {}", authorities);
-
-        UserDetails principal = new User(claims.getSubject(), "", authorities);
+        UserDetails principal = new User(subject, "", authorities);
         return new UsernamePasswordAuthenticationToken(principal, "", authorities);
     }
 
-    // 토큰 정보를 검증하는 메서드
-    public boolean validateToken(String token) {
+    /**
+     * 토큰 유효성 검사
+     * @param token 토큰
+     * @param response 응답
+     * @return 유효성 여부
+     */
+    public boolean validateToken(String token, HttpServletResponse response) throws IOException {
         try {
             Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
             return true;
         } catch (SecurityException | MalformedJwtException e) {
-            log.info("Invalid JWT Token", e);
+            log.error("Invalid JWT Token", e);
+            response.sendRedirect("/error");
         } catch (ExpiredJwtException e) {
-            log.info("Expired JWT Token", e);
-            throw new JwtTokenException("JWT 토큰 만료");
+            log.error("만료된 액세스 토큰 사용!!", e);
+            return false;
         } catch (UnsupportedJwtException e) {
-            log.info("Unsupported JWT Token", e);
+            log.error("Unsupported JWT Token", e);
         } catch (IllegalArgumentException e) {
-            log.info("JWT claims string is empty.", e);
+            log.error("JWT claims string is empty.", e);
         }
         return false;
     }
 
-    private Claims parseClaims(String accessToken) {
-        try {
-            return Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(accessToken).getBody();
-        } catch (ExpiredJwtException e) {
-            // ???
-            return e.getClaims();
-        }
-    }
 
     public String resolveToken(HttpServletRequest request) {
         String bearerToken = request.getHeader(AUTHORIZATION_HEADER);
@@ -148,4 +173,95 @@ public class JwtTokenProvider {
         }
         return null;
     }
+
+    /**
+     * AccessToken 생성 메소드
+     * @param name 회원 식별자
+     * @param inputAuthorities 권한
+     * @return AccessToken
+     */
+    public String generateAccessToken(String name,  Collection<? extends GrantedAuthority> inputAuthorities){
+        // 권한 가져오기
+        String authorities = inputAuthorities.stream()
+                .map(GrantedAuthority::getAuthority)
+                .collect(Collectors.joining(","));
+
+        Date now = new Date();
+
+        return Jwts.builder()
+                .setSubject(name)
+                .claim(AUTHORITIES_KEY, authorities)
+                .claim("type", TYPE_ACCESS)
+                .setIssuedAt(now) // 토큰 발행 시간 정보
+                .setExpiration(new Date(now.getTime() + ExpireTime.ACCESS_TOKEN_EXPIRE_TIME)) // 토큰 만료 시간 설정
+                .signWith(key, SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+
+    /**
+     * 토큰을 이용하여 Authentication 객체를 생성하는 메서드
+     * @param token 토큰
+     * @param memberId 회원 식별자
+     * @return UsernamePasswordAuthenticationToken
+     */
+    public UsernamePasswordAuthenticationToken createAuthenticationFromToken(String token, String memberId) throws TokenNotFoundException{
+
+        Authentication authentication = getAuthentication(token, memberId);
+        UserDetails userDetails = customUserDetailsService.loadUserByUsername(authentication.getName());
+
+        return new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+    }
+
+    private void saveCookie(HttpServletResponse response, String AccessToken) {
+        Cookie cookie = new Cookie("accessToken", AccessToken);
+        cookie.setPath("/");
+        cookie.setDomain(cookieResponseDomain); // 특정 도메인에서 사용하도록
+        cookie.setHttpOnly(true);
+        cookie.setMaxAge(cookieMaxAge);
+        response.addCookie(cookie);
+    }
+
+    public UsernamePasswordAuthenticationToken replaceAccessToken(HttpServletResponse response, String token) throws IOException {
+        try{
+            // redis 엔티티 조회
+            TokenRedis tokenRedis = tokenRedisRepository.findByAccessToken(token).orElseThrow(() -> new TokenNotFoundException("다시 로그인 해 주세요."));
+            String refreshToken = tokenRedis.getRefreshToken();
+
+            // 리프레시 토큰 유효성 검사
+            Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(refreshToken);
+
+            log.error("## 토큰 재발급 시작..");
+
+            String memberId = tokenRedis.getId();
+
+            // authentication 생성
+            UsernamePasswordAuthenticationToken authentication = createAuthenticationFromToken(refreshToken,memberId);
+            // 새로운 액세스 토큰 발급
+            String newAccessToken = generateAccessToken(tokenRedis.getId(), authentication.getAuthorities());
+
+            // 쿠키 AccessToken 업데이트
+            saveCookie(response, newAccessToken);
+
+            // redis AccessToken 업데이트
+            tokenRedis.updateAccessToken(newAccessToken);
+            tokenRedisRepository.save(tokenRedis);
+            log.error("## 토큰 재발급 완료!");
+
+            return authentication;
+
+        } catch (ExpiredJwtException | TokenNotFoundException exception) { // 이미 재 발급된 토큰 사용 or  리프레시 토큰 만료
+            log.error(exception.getMessage());
+            response.sendRedirect("/error");
+        } catch (RedisException redisException){
+            log.error(redisException.getMessage());
+            response.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR, "Redis 서버 에러");
+        }
+        return null;
+    }
+
+
+
+
+
 }


### PR DESCRIPTION
## 변경 타입

- [ ] 버그 수정
- [x] 새로운 기능
- [ ] 변경사항 파기 (수정 혹은 개발된 기능이 예상대로 작동하지 않을 경우)
- [ ] 문서 업데이트

## 설명

- 기존 AccessToken 만을 이용해서 Authentication을 관리하던 것을 refreshToken도 사용하도록 변경
- 토큰을 클라이언트에게 넘기고 클라이언트가 관리하던 것을, 쿠키에 httponly로 저장하여 관리하도록 변경
- Redis에 id, AccessToken, RefreshToken을 저장하여 관리
- FIX #7 

## 추가사항 ex) 스크린샷

![image](https://github.com/cutepassions/Lost-in-Frost/assets/105566077/b3e8eb22-1459-4fee-b534-01db3e194682)

