### PR TITLE
fix: 액세스토큰 업데이트 시 TTL 리셋 현상 수정

### DIFF
--- a/backend/auth-service/src/main/java/io/ssafy/authservice/global/config/RedisRepositoryConfig.java
+++ b/backend/auth-service/src/main/java/io/ssafy/authservice/global/config/RedisRepositoryConfig.java
@@ -1,7 +1,6 @@
 package io.ssafy.authservice.global.config;
 
 import io.ssafy.authservice.member.entity.TokenRedis;
-import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -9,12 +8,16 @@ import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisKeyValueAdapter;
+import org.springframework.data.redis.core.RedisKeyValueTemplate;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.mapping.RedisMappingContext;
 import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
 import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @Configuration
 @EnableRedisRepositories(enableKeyspaceEvents = RedisKeyValueAdapter.EnableKeyspaceEvents.ON_STARTUP)
+//@EnableTransactionManagement
 public class RedisRepositoryConfig {
 
     @Value("${spring.data.redis.host}")
@@ -37,12 +40,25 @@ public class RedisRepositoryConfig {
     }
 
     @Bean
-    public RedisTemplate<String, TokenRedis> redisTemplate() {
-        RedisTemplate<String, TokenRedis> redisTemplate = new RedisTemplate<>();
+    public RedisTemplate<TokenRedis, String> redisTemplate() {
+        RedisTemplate<TokenRedis, String> redisTemplate = new RedisTemplate<>();
         redisTemplate.setConnectionFactory(redisConnectionFactory());
-        redisTemplate.setDefaultSerializer(new GenericJackson2JsonRedisSerializer());
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new GenericJackson2JsonRedisSerializer());
         return redisTemplate;
     }
+
+    @Bean
+    public RedisKeyValueTemplate redisKeyValueTemplate(RedisConnectionFactory redisConnectionFactory) {
+        RedisTemplate<String, TokenRedis> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory);
+        redisTemplate.afterPropertiesSet();
+        return new RedisKeyValueTemplate(new RedisKeyValueAdapter(redisTemplate), new RedisMappingContext());
+    }
+
+
+
+
 
 
 }

--- a/backend/auth-service/src/main/java/io/ssafy/authservice/global/config/security/ExpireTime.java
+++ b/backend/auth-service/src/main/java/io/ssafy/authservice/global/config/security/ExpireTime.java
@@ -4,6 +4,7 @@ import org.springframework.beans.factory.annotation.Value;
 
 public class ExpireTime {
 
-    public static final Long ACCESS_TOKEN_EXPIRE_TIME = 21600000L; // 6시간
-    // public static final long ACCESS_TOKEN_EXPIRE_TIME = 6 * 6 * 1000L; //36초
+//    public static final long ACCESS_TOKEN_EXPIRE_TIME = 30 * 60 * 1000L; // 30분
+    public static final long ACCESS_TOKEN_EXPIRE_TIME = 3 * 1000L; // 3초
+    public static final long REFRESH_TOKEN__EXPIRE_TIME = 7 * 24 * 60 * 60 * 1000L; // 7일
 }

--- a/backend/auth-service/src/main/java/io/ssafy/authservice/member/entity/TokenRedis.java
+++ b/backend/auth-service/src/main/java/io/ssafy/authservice/member/entity/TokenRedis.java
@@ -2,25 +2,23 @@ package io.ssafy.authservice.member.entity;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.redis.core.RedisHash;
 import org.springframework.data.redis.core.index.Indexed;
 
 @Getter
 @AllArgsConstructor
+@RequiredArgsConstructor
 @RedisHash(value = "token", timeToLive = 60 * 60 * 24 * 7) // 7 일
 public class TokenRedis {
 
     @Id
-    private String id;
+    private String memberId;
 
     @Indexed
     private String accessToken;
 
     private String refreshToken;
-
-    public void updateAccessToken(String accessToken) {
-        this.accessToken = accessToken;
-    }
 
 }

--- a/backend/auth-service/src/main/java/io/ssafy/authservice/oauth2/cookie/CookieUtils.java
+++ b/backend/auth-service/src/main/java/io/ssafy/authservice/oauth2/cookie/CookieUtils.java
@@ -12,6 +12,7 @@ import java.util.Arrays;
 import java.util.Base64;
 import java.util.Optional;
 
+@Component
 public class CookieUtils {
 
 

--- a/backend/auth-service/src/main/java/io/ssafy/authservice/oauth2/dto/UserResponseDto.java
+++ b/backend/auth-service/src/main/java/io/ssafy/authservice/oauth2/dto/UserResponseDto.java
@@ -13,5 +13,7 @@ public class UserResponseDto {
         private String grantType;
         private String accessToken;
         private Long accessTokenExpirationTime;
+        private String refreshToken;
+        private Long refreshTokenExpirationTime;
     }
 }

--- a/backend/auth-service/src/main/java/io/ssafy/authservice/oauth2/jwt/JwtAuthenticationFilter.java
+++ b/backend/auth-service/src/main/java/io/ssafy/authservice/oauth2/jwt/JwtAuthenticationFilter.java
@@ -25,8 +25,6 @@ import java.util.Optional;
 public class JwtAuthenticationFilter extends GenericFilterBean {
 
     private final JwtTokenProvider jwtTokenProvider;
-    private final CustomUserDetailsService customUserDetailsService;
-
 
 
     @Override
@@ -36,15 +34,13 @@ public class JwtAuthenticationFilter extends GenericFilterBean {
         // 쿠키에서 토큰 추출
         Optional<Cookie> accessToken = CookieUtils.getCookie((HttpServletRequest) servletRequest,"accessToken" );
         if (accessToken.isPresent()) {
-            boolean validToken = jwtTokenProvider.validateToken(String.valueOf(accessToken.get().getValue()), (HttpServletResponse) servletResponse);
+            String validToken = jwtTokenProvider.validateToken(String.valueOf(accessToken.get().getValue()), (HttpServletResponse) servletResponse);
             UsernamePasswordAuthenticationToken authentication;
-            if (validToken) {
-                // authentication 생성
-                authentication = jwtTokenProvider.createAuthenticationFromToken(accessToken.get().getValue(), null);
-                // security 추가
-            } else {
-                // 토큰이 만료되었을 경우
-                // 새로운 토큰 발급
+            if (validToken != null) {
+                authentication = jwtTokenProvider.createAuthenticationFromToken(accessToken.get().getValue(), validToken);
+            }
+            // 토큰이 만료되었을 경우 -> 새로운 토큰 발급
+            else {
                 authentication = jwtTokenProvider.replaceAccessToken((HttpServletResponse) servletResponse, accessToken.get().getValue());
             }
             SecurityContextHolder.getContext().setAuthentication(authentication);


### PR DESCRIPTION
## 변경 타입

- [X] 버그 수정
- [ ] 새로운 기능
- [ ] 변경사항 파기 (수정 혹은 개발된 기능이 예상대로 작동하지 않을 경우)
- [ ] 문서 업데이트

## 설명

- 액세스 토큰을 재발급시에, TTL 리셋되던 현상을 수정
- FIX #10

## 추가사항 ex) 스크린샷
> 기존 TTL 확인 > 만료된 토큰 API 요청 > 토큰 재발급 > TTL 갱신 X

![](https://velog.velcdn.com/images/cutepassions/post/005dcfbe-2df5-4cb8-a4c8-07844f05cd55/image.gif)
