### PR TITLE
fix: 한 번 인증이 완료된 요청에 대한 재인증 미실시

### DIFF
--- a/backend/auth-service/src/main/java/io/ssafy/authservice/oauth2/jwt/OncePerRequestFilter.java
+++ b/backend/auth-service/src/main/java/io/ssafy/authservice/oauth2/jwt/OncePerRequestFilter.java
@@ -1,51 +1,44 @@
 package io.ssafy.authservice.oauth2.jwt;
 
 import io.ssafy.authservice.oauth2.cookie.CookieUtils;
-import io.ssafy.authservice.oauth2.service.CustomUserDetailsService;
+import io.ssafy.authservice.oauth2.jwt.JwtTokenProvider;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
-import jakarta.servlet.ServletRequest;
-import jakarta.servlet.ServletResponse;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.core.userdetails.UserDetails;
-import org.springframework.web.filter.GenericFilterBean;
 
 import java.io.IOException;
 import java.util.Optional;
 
 @Slf4j
 @RequiredArgsConstructor
-public class JwtAuthenticationFilter extends GenericFilterBean {
+public class OncePerRequestFilter extends org.springframework.web.filter.OncePerRequestFilter {
 
     private final JwtTokenProvider jwtTokenProvider;
 
-
     @Override
-    public void doFilter(ServletRequest servletRequest, ServletResponse servletResponse, FilterChain filterChain) throws IOException, ServletException {
-        log.debug("## doFilter 동작!!");
-        
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        log.debug("## doFilterInternal 동작!!");
+
         // 쿠키에서 토큰 추출
-        Optional<Cookie> accessToken = CookieUtils.getCookie((HttpServletRequest) servletRequest,"accessToken" );
+        Optional<Cookie> accessToken = CookieUtils.getCookie(request,"accessToken" );
         if (accessToken.isPresent()) {
-            String validToken = jwtTokenProvider.validateToken(String.valueOf(accessToken.get().getValue()), (HttpServletResponse) servletResponse);
+            String validToken = jwtTokenProvider.validateToken(String.valueOf(accessToken.get().getValue()), response);
             UsernamePasswordAuthenticationToken authentication;
             if (validToken != null) {
                 authentication = jwtTokenProvider.createAuthenticationFromToken(accessToken.get().getValue(), validToken);
             }
             // 토큰이 만료되었을 경우 -> 새로운 토큰 발급
             else {
-                authentication = jwtTokenProvider.replaceAccessToken((HttpServletResponse) servletResponse, accessToken.get().getValue());
+                authentication = jwtTokenProvider.replaceAccessToken(response, accessToken.get().getValue());
             }
             SecurityContextHolder.getContext().setAuthentication(authentication);
         }
-            filterChain.doFilter(servletRequest, servletResponse);
+        filterChain.doFilter(request, response);
     }
-
 }


### PR DESCRIPTION
## 변경 타입

- [X] 버그 수정
- [ ] 새로운 기능
- [ ] 변경사항 파기 (수정 혹은 개발된 기능이 예상대로 작동하지 않을 경우)
- [ ] 문서 업데이트

## 설명

- 이미 요청에 대한 인증 처리가 이루어졌음에도, 내부 요청에 연쇄적으로 발생 시 계속해서 인증처리가 이루어짐
- 불필요한 인증 처리 방지를 위한 로직 변경
- 기존의 GenericFilterBean을 상속 받는 대신 OncePerRequestFilter를 사용하여 최초 1회에 한하여 인증 처리 실시
- FIX #9 

## 추가사항 ex) 스크린샷
> API 요청 > 인증 완료 > /error 발생 (404 발생) > 404 return > 클라이언트 404 확인

![](https://velog.velcdn.com/images/cutepassions/post/521a8b7a-2c46-4e5f-8346-832c642834a3/image.gif)
