### PR TITLE
feat: user-service의 Member엔티티에 인덱스 추가 및 회원 랭킹 변동 컬럼을 Enum을 사용하도록 변경

### DIFF
--- a/backend/user-service/src/main/java/io/ssafy/userservice/user/member/entity/Member.java
+++ b/backend/user-service/src/main/java/io/ssafy/userservice/user/member/entity/Member.java
@@ -3,6 +3,7 @@ package io.ssafy.userservice.user.member.entity;
 import io.ssafy.userservice.oauth2.enums.AuthProvider;
 import io.ssafy.userservice.oauth2.enums.Role;
 import io.ssafy.userservice.oauth2.userinfo.OAuth2UserInfo;
+import io.ssafy.userservice.user.member.enums.RankingChange;
 import io.ssafy.userservice.user.mycostume.entity.MyCostume;
 import jakarta.persistence.*;
 import jakarta.persistence.Index;
@@ -26,7 +27,9 @@ import java.util.*;
         @Index(name = "idx_member_email", columnList = "member_email"),
         @Index(name = "idx_member_nickname", columnList = "member_nickname"),
         @Index(name = "idx_member_role", columnList = "member_role"),
-        @Index(name = "idx_member_is_deleted", columnList = "member_is_deleted")
+        @Index(name = "idx_member_is_deleted", columnList = "member_is_deleted"),
+        @Index(name = "idx_member_level", columnList = "member_level"),
+        @Index(name = "idx_member_experience", columnList = "member_experience")
 })
 public class Member implements UserDetails {
 
@@ -139,8 +142,8 @@ public class Member implements UserDetails {
 
     @Column(name = "member_ranking_change")
     @Comment("회원 랭킹 변동")
-    @ColumnDefault(value = "'NEW'")
-    private String rankingChange;
+    @Enumerated(EnumType.STRING)
+    private RankingChange rankingChange;
 
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
@@ -214,7 +217,7 @@ public class Member implements UserDetails {
         this.isDeleted = true;
     }
 
-    public void updateRank(int rank, Timestamp rankUpdateDateTIme, String rankingChange) {
+    public void updateRank(int rank, Timestamp rankUpdateDateTIme, RankingChange rankingChange) {
         this.rank = rank;
         this.rankUpdateDateTIme = rankUpdateDateTIme;
         this.rankingChange = rankingChange;

--- a/backend/user-service/src/main/java/io/ssafy/userservice/user/member/enums/RankingChange.java
+++ b/backend/user-service/src/main/java/io/ssafy/userservice/user/member/enums/RankingChange.java
@@ -1,0 +1,16 @@
+package io.ssafy.userservice.user.member.enums;
+
+import lombok.Getter;
+
+@Getter
+public enum RankingChange {
+    UP("상승"),
+    DOWN("하락"),
+    KEEP("유지");
+
+    private final String description;
+
+    RankingChange(String description) {
+        this.description=description;
+    }
+}


### PR DESCRIPTION
## 변경 타입

- [X] 새로운 기능

## 설명
- Member 엔티티에 빠른 랭킹 조회를 위한 레벨과 경험치에 인덱스 추가
- Member 엔티티의 랭킹 변화 컬럼의 타입을 Enum으로 변경

## 추가사항 ex) 스크린샷

- 없음.
